### PR TITLE
✨ Toggle menu bar visibility w/ Dock

### DIFF
--- a/AutoDock.xcodeproj/project.pbxproj
+++ b/AutoDock.xcodeproj/project.pbxproj
@@ -282,7 +282,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 120;
 				DEVELOPMENT_ASSET_PATHS = "\"AutoDock/Preview Content\"";
 				DEVELOPMENT_TEAM = B3DFV278UN;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -299,7 +299,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ghalldev.AutoDock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -316,7 +316,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 120;
 				DEVELOPMENT_ASSET_PATHS = "\"AutoDock/Preview Content\"";
 				DEVELOPMENT_TEAM = B3DFV278UN;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -333,7 +333,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ghalldev.AutoDock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/AutoDock/Views/SettingsView.swift
+++ b/AutoDock/Views/SettingsView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct SettingsView: View {
 	@AppStorage("minResolutionToShowDock") private var minResolutionToShowDock: CGRect = .zero
 	@AppStorage("autoUpdate") private var autoUpdate = true
+	@AppStorage("alsoToggleMenubar") var alsoToggleMenubar = false
+	
 	@EnvironmentObject var displayManager: DisplayManager
 
 	var body: some View {
@@ -27,6 +29,9 @@ struct SettingsView: View {
 				}
 			}
 			Section {
+				Toggle("Also toggle Menu Bar", isOn: $alsoToggleMenubar)
+			}
+			Section {
 				LaunchAtLogin.Toggle()
 
 				VStack(alignment: .leading) {
@@ -45,7 +50,7 @@ struct SettingsView: View {
 			}
 		}
 		.formStyle(.grouped)
-		.frame(width: 400, height: 200)
+		.frame(width: 400, height: 240)
 	}
 
 	private func createLabel(_ value: CGRect) -> String {


### PR DESCRIPTION
Added an option to toggle the menu bar to hidden/visible based on dock visibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option in settings to also toggle the Menu Bar autohide alongside the Dock autohide.
  * Introduced a new toggle control in the settings UI for this feature.

* **Improvements**
  * Settings screen height increased to better accommodate new options.

* **Chores**
  * Updated app version to 1.2.0 (build 120).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->